### PR TITLE
add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+.DS_Store?
+
+.sass_cache


### PR DESCRIPTION
Para simplificar el proyecto, agregué un .gitignore sencillo para ignorar:
- .DS_Store (archivo que crea macOS para carpetas)
- .sass_cache

No ignora ni bower_components ni node_modules para asegurar compatibilidad.
